### PR TITLE
/browser url

### DIFF
--- a/src/main/java/io/github/blobanium/mcbrowser/MCBrowser.java
+++ b/src/main/java/io/github/blobanium/mcbrowser/MCBrowser.java
@@ -1,6 +1,8 @@
 package io.github.blobanium.mcbrowser;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
 import io.github.blobanium.mcbrowser.config.BrowserAutoConfig;
+import io.github.blobanium.mcbrowser.feature.BrowserUtil;
 import io.github.blobanium.mcbrowser.screen.BrowserScreen;
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
@@ -25,24 +27,21 @@ public class MCBrowser implements ClientModInitializer {
         AutoConfig.register(BrowserAutoConfig.class, GsonConfigSerializer::new);
 
         ClientTickEvents.START_CLIENT_TICK.register((client) -> onTick());
-
-        ClientCommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess) -> {
-            dispatcher.register(ClientCommandManager.literal("browser")
-                    .executes(context -> {
-                        openBrowser(getConfig().homePage);
-                        return 0;
-                    })
-            );
-        }));
-
-        ClientCommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess) -> {
-            dispatcher.register(ClientCommandManager.literal("br")
-                    .executes(context -> {
-                        openBrowser(getConfig().homePage);
-                        return 0;
-                    })
-            );
-        }));
+        for (String command : new String[]{"browser", "br"}) {
+            ClientCommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess) -> {
+                dispatcher.register(ClientCommandManager.literal(command)
+                        .executes(context -> {
+                            openBrowser(getConfig().homePage);
+                            return 0;
+                        }).then(ClientCommandManager.argument("url", StringArgumentType.greedyString())
+                                .executes(context -> {
+                                    openBrowser(BrowserUtil.prediffyURL(StringArgumentType.getString(context, "url")));
+                                    return 0;
+                                })
+                        )
+                );
+            }));
+        }
     }
     private static final MinecraftClient minecraft = MinecraftClient.getInstance();
 


### PR DESCRIPTION
Added ability to open url from command.
Use `/browser github.com` and it will open browser on this page instead of default one.
Searches as `/browser how to craft a sword in minecraft` work too as well.