### PR TITLE
Fix tab switching issue (1.21)

### DIFF
--- a/src/main/java/io/github/blobanium/mcbrowser/screen/BrowserScreen.java
+++ b/src/main/java/io/github/blobanium/mcbrowser/screen/BrowserScreen.java
@@ -35,7 +35,7 @@ public class BrowserScreen extends Screen {
     private int previousLimit;
     private boolean isFpsLowered = false;
 
-    private final BrowserImpl currentTab = TabManager.getCurrentTab();
+    public BrowserImpl currentTab = TabManager.getCurrentTab();
 
     public BrowserScreen(Text title) {
         super(title);

--- a/src/main/java/io/github/blobanium/mcbrowser/util/TabManager.java
+++ b/src/main/java/io/github/blobanium/mcbrowser/util/TabManager.java
@@ -25,7 +25,8 @@ public class TabManager {
 
     public static void setActiveTab(int index) {
         activeTab = index;
-        if (MinecraftClient.getInstance().currentScreen instanceof BrowserScreen) {
+        if (MinecraftClient.getInstance().currentScreen instanceof BrowserScreen screen) {
+            screen.currentTab = getCurrentTab();
             BrowserUtil.instance.updateWidgets();
         }
     }


### PR DESCRIPTION
Fixed the issue where, if you switch the active tab, the actual browser window won't update until you close and open the browser screen.